### PR TITLE
Fix attribute null check

### DIFF
--- a/pynamodb_encoder/encoder.py
+++ b/pynamodb_encoder/encoder.py
@@ -20,7 +20,7 @@ class Encoder:
         encoded = {}
         for name, attr in container.get_attributes().items():
             value = getattr(container, name)
-            if value:
+            if value is not None:
                 encoded[name] = self.encode_attribute(attr, value)
         return encoded
 


### PR DESCRIPTION
The use of

```python
if value:
```

on line 23 of `encoder.py` coerces empty containers to `False` and prevents them from being encoded. This means that empty lists, dicts, strings, etc. are not encoded.

I didn't see a test for this case, so I figured this was an error and made a PR that explicitly checks that `value is not None`.